### PR TITLE
add explicit kotlin compiler api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kotlin.code.style>official</kotlin.code.style>
     <kotlin.version>2.1.0</kotlin.version>
+    <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
 
     <java.version>17</java.version>
     <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
Har forsøkt å bygge tomra prosjektene med intellij, men den velger å bruker kotlin api versjon 1.8 som default. Pratet med andre som har samme feil, men de får fikset det med å eksplisitt endre den til 2.1. Jeg får uheldigvis ikke fikset det på denne måten, og jeg mistenker at den kommer til å bli satt tilbake når man reimporterer fra pom-en.
Dette burde fikse dette.