### PR TITLE
cals-1278: use correct org reference in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capraconsulting/renovate-config:default"
+    "github>capralifecycle/renovate-config:default"
   ],
   "automerge": true,
   "automergeType": "branch",


### PR DESCRIPTION
Update org-reference in Renovate config to avoid relying on GitHub redirects.

CALS-1278